### PR TITLE
fixed white wires on lower layer, added pass throughs for pogo

### DIFF
--- a/Hardware/TestJig/Jig-Lower-Layer.brd
+++ b/Hardware/TestJig/Jig-Lower-Layer.brd
@@ -898,9 +898,9 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <element name="JP6" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="59.69" y="2.54"/>
 <element name="D1" library="SparkFun-LED" package="LED_5MM" value="" x="12.7" y="50.8"/>
 <element name="U$1" library="Pogo-Footprints" package="1X04" value="CONN_041" x="26.67" y="11.43"/>
-<element name="S2" library="SparkFun-Switches" package="TACTILE_SWITCH_PTH_12MM" value="RST" x="-24.13" y="-33.02">
-<attribute name="PROD_ID" value="SWCH-09185" x="-24.13" y="-33.02" size="1.778" layer="27" font="vector" ratio="15" display="off"/>
-<attribute name="SF_SKU" value="COM-09190" x="-24.13" y="-33.02" size="1.778" layer="27" font="vector" ratio="15" display="off"/>
+<element name="S2" library="SparkFun-Switches" package="TACTILE_SWITCH_PTH_12MM" value="RST" x="69.85" y="72.39">
+<attribute name="PROD_ID" value="SWCH-09185" x="69.85" y="72.39" size="1.778" layer="27" font="vector" ratio="15" display="off"/>
+<attribute name="SF_SKU" value="COM-09190" x="69.85" y="72.39" size="1.778" layer="27" font="vector" ratio="15" display="off"/>
 </element>
 </elements>
 <signals>
@@ -949,7 +949,7 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <contactref element="U$1" pad="1"/>
 <wire x1="26.67" y1="11.43" x2="26.67" y2="26.67" width="0.254" layer="1"/>
 <contactref element="S2" pad="1"/>
-<wire x1="26.67" y1="11.43" x2="-17.88" y2="-35.52" width="0" layer="19" extent="1-1"/>
+<wire x1="53.34" y1="41.91" x2="76.1" y2="69.89" width="0" layer="19" extent="1-1"/>
 </signal>
 <signal name="ADR/MOSI">
 <contactref element="J6" pad="5"/>
@@ -994,7 +994,8 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <signal name="!CS">
 <contactref element="J6" pad="6"/>
 <contactref element="B1" pad="D10"/>
-<wire x1="34.29" y1="34.29" x2="53.34" y2="31.75" width="0" layer="19" extent="1-1"/>
+<wire x1="53.34" y1="31.75" x2="36.83" y2="31.75" width="0.254" layer="16"/>
+<wire x1="36.83" y1="31.75" x2="34.29" y2="34.29" width="0.254" layer="16"/>
 </signal>
 <signal name="!INT">
 <contactref element="J7" pad="2"/>
@@ -1008,7 +1009,6 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <contactref element="J1" pad="4"/>
 <contactref element="B1" pad="SCL"/>
 <contactref element="B1" pad="D13"/>
-<wire x1="36.83" y1="7.62" x2="34.29" y2="10.16" width="0.254" layer="1"/>
 <wire x1="53.34" y1="39.37" x2="29.21" y2="39.37" width="0.254" layer="1"/>
 <wire x1="29.21" y1="39.37" x2="26.67" y2="36.83" width="0.254" layer="1"/>
 <wire x1="26.67" y1="36.83" x2="26.67" y2="34.29" width="0.254" layer="1"/>
@@ -1020,29 +1020,22 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <wire x1="54.991" y1="49.149" x2="54.991" y2="41.021" width="0.254" layer="1"/>
 <wire x1="54.991" y1="41.021" x2="53.34" y2="39.37" width="0.254" layer="1"/>
 <contactref element="U$1" pad="4"/>
-<wire x1="34.29" y1="10.16" x2="34.29" y2="11.43" width="0.254" layer="1"/>
 <wire x1="34.29" y1="15.24" x2="34.29" y2="11.43" width="0.254" layer="1"/>
 <contactref element="B1" pad="A5"/>
-<wire x1="5.08" y1="5.08" x2="31.75" y2="17.78" width="0" layer="19" extent="1-1"/>
+<wire x1="5.08" y1="5.08" x2="31.75" y2="5.08" width="0.254" layer="16"/>
+<wire x1="31.75" y1="5.08" x2="34.29" y2="7.62" width="0.254" layer="16"/>
+<wire x1="34.29" y1="7.62" x2="34.29" y2="11.43" width="0.254" layer="16"/>
 </signal>
 <signal name="SDA/MISO/TX">
 <contactref element="J6" pad="4"/>
 <contactref element="J1" pad="5"/>
 <contactref element="B1" pad="SDA"/>
 <contactref element="B1" pad="D12"/>
-<wire x1="36.83" y1="5.08" x2="31.75" y2="10.16" width="0.254" layer="1"/>
 <wire x1="29.21" y1="35.56" x2="29.21" y2="34.29" width="0.254" layer="1"/>
 <wire x1="29.21" y1="34.29" x2="34.29" y2="29.21" width="0.254" layer="1"/>
 <wire x1="53.34" y1="36.83" x2="52.07" y2="38.1" width="0.254" layer="1"/>
 <wire x1="52.07" y1="38.1" x2="31.75" y2="38.1" width="0.254" layer="1"/>
 <wire x1="31.75" y1="38.1" x2="29.21" y2="35.56" width="0.254" layer="1"/>
-<wire x1="34.29" y1="29.21" x2="34.29" y2="17.78" width="0.254" layer="1"/>
-<wire x1="34.29" y1="17.78" x2="35.56" y2="16.51" width="0.254" layer="1"/>
-<wire x1="35.56" y1="16.51" x2="35.56" y2="10.16" width="0.254" layer="1"/>
-<wire x1="35.56" y1="10.16" x2="36.83" y2="8.89" width="0.254" layer="1"/>
-<wire x1="36.83" y1="8.89" x2="54.356" y2="8.89" width="0.254" layer="1"/>
-<wire x1="54.356" y1="8.89" x2="54.991" y2="8.255" width="0.254" layer="1"/>
-<wire x1="54.991" y1="8.255" x2="54.991" y2="6.731" width="0.254" layer="1"/>
 <wire x1="53.34" y1="46.99" x2="52.07" y2="46.99" width="0.254" layer="1"/>
 <wire x1="52.07" y1="46.99" x2="50.8" y2="48.26" width="0.254" layer="1"/>
 <wire x1="50.8" y1="48.26" x2="50.8" y2="50.8" width="0.254" layer="1"/>
@@ -1053,10 +1046,13 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <wire x1="55.88" y1="38.1" x2="54.61" y2="36.83" width="0.254" layer="1"/>
 <wire x1="54.61" y1="36.83" x2="53.34" y2="36.83" width="0.254" layer="1"/>
 <contactref element="U$1" pad="3"/>
-<wire x1="31.75" y1="10.16" x2="31.75" y2="11.43" width="0.254" layer="1"/>
 <contactref element="B1" pad="A4"/>
-<wire x1="36.83" y1="5.08" x2="36.83" y2="8.89" width="0" layer="19" extent="1-1"/>
-<wire x1="5.08" y1="7.62" x2="31.75" y2="10.16" width="0" layer="19" extent="1-1"/>
+<wire x1="5.08" y1="7.62" x2="30.48" y2="7.62" width="0.254" layer="16"/>
+<wire x1="30.48" y1="7.62" x2="31.75" y2="8.89" width="0.254" layer="16"/>
+<wire x1="31.75" y1="8.89" x2="31.75" y2="11.43" width="0.254" layer="16"/>
+<wire x1="34.29" y1="29.21" x2="34.29" y2="19.05" width="0.254" layer="16"/>
+<wire x1="34.29" y1="19.05" x2="31.75" y2="16.51" width="0.254" layer="16"/>
+<wire x1="31.75" y1="16.51" x2="31.75" y2="11.43" width="0.254" layer="16"/>
 </signal>
 <signal name="!RST">
 <contactref element="J7" pad="1"/>
@@ -1092,7 +1088,7 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <signal name="N$3">
 <contactref element="B1" pad="RES"/>
 <contactref element="S2" pad="3"/>
-<wire x1="5.08" y1="35.56" x2="-17.88" y2="-30.52" width="0" layer="19" extent="1-1"/>
+<wire x1="5.08" y1="35.56" x2="76.1" y2="74.89" width="0" layer="19" extent="1-1"/>
 </signal>
 </signals>
 </board>

--- a/Hardware/TestJig/Jig-Middle-Layer.brd
+++ b/Hardware/TestJig/Jig-Middle-Layer.brd
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.005" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -56,7 +56,7 @@
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
 <layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="yes"/>
 <layer number="51" name="tDocu" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="52" name="bDocu" color="7" fill="1" visible="no" active="yes"/>
@@ -274,6 +274,15 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </package>
 </packages>
 </library>
+<library name="KevinKuwata_eagle">
+<packages>
+<package name="POGO_PIN_TIGHT">
+<pad name="P1" x="0" y="0" drill="1.45" diameter="2.1844"/>
+<text x="-1.27" y="1.27" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.27" y="-2.54" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+</packages>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -470,6 +479,28 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <element name="JP5" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="2.54" y="52.07"/>
 <element name="JP6" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="2.54" y="2.54"/>
 <element name="U$4" library="Pogo-Footprints" package="1X01_POGO_HEAD" value="POGO_HEAD_11" x="16.51" y="17.78"/>
+<element name="J1" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="21.59" y="34.29"/>
+<element name="J2" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="24.13" y="34.29"/>
+<element name="J3" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="26.67" y="34.29"/>
+<element name="J4" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="29.21" y="34.29"/>
+<element name="J5" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="31.75" y="34.29"/>
+<element name="J6" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="34.29" y="34.29"/>
+<element name="J7" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="36.83" y="34.29"/>
+<element name="J8" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="39.37" y="34.29"/>
+<element name="J9" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="24.13" y="29.21"/>
+<element name="J10" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="31.75" y="29.21"/>
+<element name="J11" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="26.67" y="29.21"/>
+<element name="J12" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="34.29" y="29.21"/>
+<element name="J13" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="29.21" y="29.21"/>
+<element name="J14" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="21.59" y="11.43"/>
+<element name="J15" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="36.83" y="29.21"/>
+<element name="J16" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="24.13" y="11.43"/>
+<element name="J17" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="26.67" y="11.43"/>
+<element name="J18" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="39.37" y="11.43"/>
+<element name="J19" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="29.21" y="11.43"/>
+<element name="J21" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="31.75" y="11.43"/>
+<element name="J23" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="34.29" y="11.43"/>
+<element name="J24" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="36.83" y="11.43"/>
 </elements>
 <signals>
 </signals>

--- a/Hardware/TestJig/Jig-Middle-Layer.sch
+++ b/Hardware/TestJig/Jig-Middle-Layer.sch
@@ -358,6 +358,39 @@ Head</text>
 </deviceset>
 </devicesets>
 </library>
+<library name="KevinKuwata_eagle">
+<packages>
+<package name="POGO_PIN_TIGHT">
+<pad name="P1" x="0" y="0" drill="1.45" diameter="2.1844"/>
+<text x="-1.27" y="1.27" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.27" y="-2.54" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+</packages>
+<symbols>
+<symbol name="POGO_PIN">
+<pin name="P1" x="-2.54" y="0" length="short"/>
+<text x="-2.54" y="2.54" size="1.27" layer="95">&gt;NAME</text>
+<text x="-2.54" y="-2.54" size="1.27" layer="96">&gt;VALUE</text>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="POGO_PIN" prefix="J">
+<gates>
+<gate name="J1" symbol="POGO_PIN" x="0" y="0"/>
+</gates>
+<devices>
+<device name="TIGHT" package="POGO_PIN_TIGHT">
+<connects>
+<connect gate="J1" pin="P1" pad="P1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -372,6 +405,28 @@ Head</text>
 <part name="JP4" library="SparkFun" deviceset="STAND-OFF" device=""/>
 <part name="FRAME1" library="SparkFun-Aesthetics" deviceset="FRAME-LETTER" device=""/>
 <part name="U$4" library="Pogo-Footprints" deviceset="POGO_HEAD_1" device="1"/>
+<part name="J1" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J2" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J3" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J4" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J5" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J6" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J7" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J8" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J9" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J10" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J11" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J12" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J13" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J14" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J15" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J16" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J17" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J18" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J19" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J21" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J23" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
+<part name="J24" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
 </parts>
 <sheets>
 <sheet>
@@ -421,7 +476,29 @@ SPI</text>
 <instance part="JP4" gate="G$1" x="246.38" y="27.94"/>
 <instance part="FRAME1" gate="G$1" x="0" y="0"/>
 <instance part="FRAME1" gate="V" x="147.32" y="0"/>
-<instance part="U$4" gate="G$1" x="53.34" y="116.84"/>
+<instance part="U$4" gate="G$1" x="15.24" y="162.56"/>
+<instance part="J1" gate="J1" x="22.86" y="134.62"/>
+<instance part="J2" gate="J1" x="22.86" y="124.46"/>
+<instance part="J3" gate="J1" x="22.86" y="114.3"/>
+<instance part="J4" gate="J1" x="22.86" y="104.14"/>
+<instance part="J5" gate="J1" x="50.8" y="134.62"/>
+<instance part="J6" gate="J1" x="50.8" y="124.46"/>
+<instance part="J7" gate="J1" x="50.8" y="114.3"/>
+<instance part="J8" gate="J1" x="50.8" y="104.14"/>
+<instance part="J9" gate="J1" x="76.2" y="134.62"/>
+<instance part="J10" gate="J1" x="76.2" y="124.46"/>
+<instance part="J11" gate="J1" x="76.2" y="114.3"/>
+<instance part="J12" gate="J1" x="76.2" y="104.14"/>
+<instance part="J13" gate="J1" x="104.14" y="134.62"/>
+<instance part="J14" gate="J1" x="104.14" y="124.46"/>
+<instance part="J15" gate="J1" x="104.14" y="114.3"/>
+<instance part="J16" gate="J1" x="104.14" y="104.14"/>
+<instance part="J17" gate="J1" x="132.08" y="134.62"/>
+<instance part="J18" gate="J1" x="132.08" y="124.46"/>
+<instance part="J19" gate="J1" x="132.08" y="114.3"/>
+<instance part="J21" gate="J1" x="160.02" y="134.62"/>
+<instance part="J23" gate="J1" x="160.02" y="114.3"/>
+<instance part="J24" gate="J1" x="160.02" y="104.14"/>
 </instances>
 <busses>
 </busses>


### PR DESCRIPTION
replaced white wires with bottom traces. 3  traces:  A4, A5, CS

added PTH holes with 1.45mm diameter, giving .15mm clearance of the pogo pin head.

removed cutouts so PCBs can be fabricated