### PR TITLE
Tweaked testjig middle and top layers

### DIFF
--- a/Hardware/TestJig/Jig-Middle-Layer.brd
+++ b/Hardware/TestJig/Jig-Middle-Layer.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.7.0">
+<eagle version="7.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>
@@ -8,7 +8,7 @@
 </settings>
 <grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.005" altunitdist="inch" altunit="inch"/>
 <layers>
-<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="1" name="Top" color="4" fill="1" visible="no" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
 <layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
 <layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
@@ -23,15 +23,15 @@
 <layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
 <layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
 <layer number="15" name="Route15" color="4" fill="6" visible="no" active="no"/>
-<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
-<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
-<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
-<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="no" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="no" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="yes"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="21" name="tPlace" color="16" fill="1" visible="yes" active="yes"/>
-<layer number="22" name="bPlace" color="14" fill="1" visible="yes" active="yes"/>
-<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="16" fill="1" visible="no" active="yes"/>
+<layer number="22" name="bPlace" color="14" fill="1" visible="no" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
@@ -52,13 +52,13 @@
 <layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
-<layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
 <layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="yes"/>
-<layer number="51" name="tDocu" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="51" name="tDocu" color="6" fill="1" visible="no" active="yes"/>
 <layer number="52" name="bDocu" color="7" fill="1" visible="no" active="yes"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
@@ -198,22 +198,47 @@
 <wire x1="22.86" y1="30.48" x2="22.86" y2="27.94" width="0.1524" layer="22"/>
 <wire x1="22.86" y1="27.94" x2="38.1" y2="27.94" width="0.1524" layer="22"/>
 <wire x1="38.1" y1="27.94" x2="38.1" y2="30.48" width="0.1524" layer="22"/>
-<wire x1="0" y1="0" x2="62.23" y2="0" width="0.254" layer="20"/>
-<wire x1="62.23" y1="0" x2="62.23" y2="54.61" width="0.254" layer="20"/>
-<wire x1="62.23" y1="54.61" x2="0" y2="54.61" width="0.254" layer="20"/>
-<wire x1="0" y1="54.61" x2="0" y2="0" width="0.254" layer="20"/>
-<wire x1="22.225" y1="31.115" x2="38.735" y2="31.115" width="0.254" layer="20"/>
-<wire x1="38.735" y1="31.115" x2="38.735" y2="27.305" width="0.254" layer="20"/>
-<wire x1="38.735" y1="27.305" x2="22.225" y2="27.305" width="0.254" layer="20"/>
-<wire x1="22.225" y1="27.305" x2="22.225" y2="31.115" width="0.254" layer="20"/>
-<wire x1="19.685" y1="36.195" x2="41.275" y2="36.195" width="0.254" layer="20"/>
-<wire x1="41.275" y1="36.195" x2="41.275" y2="32.385" width="0.254" layer="20"/>
-<wire x1="41.275" y1="32.385" x2="19.685" y2="32.385" width="0.254" layer="20"/>
-<wire x1="19.685" y1="32.385" x2="19.685" y2="36.195" width="0.254" layer="20"/>
-<wire x1="19.685" y1="13.335" x2="41.275" y2="13.335" width="0.254" layer="20"/>
-<wire x1="41.275" y1="13.335" x2="41.275" y2="9.525" width="0.254" layer="20"/>
-<wire x1="41.275" y1="9.525" x2="19.685" y2="9.525" width="0.254" layer="20"/>
-<wire x1="19.685" y1="9.525" x2="19.685" y2="13.335" width="0.254" layer="20"/>
+<wire x1="-1.27" y1="52.07" x2="-1.27" y2="2.54" width="0.254" layer="20"/>
+<wire x1="-1.27" y1="2.54" x2="2.54" y2="-1.27" width="0.254" layer="20" curve="90"/>
+<wire x1="2.54" y1="-1.27" x2="59.69" y2="-1.27" width="0.254" layer="20"/>
+<wire x1="59.69" y1="-1.27" x2="63.5" y2="2.54" width="0.254" layer="20" curve="90"/>
+<wire x1="63.5" y1="2.54" x2="63.5" y2="5.08" width="0.254" layer="20"/>
+<wire x1="63.5" y1="5.08" x2="59.69" y2="7.62" width="0.254" layer="20" curve="90"/>
+<wire x1="59.69" y1="7.62" x2="54.392103125" y2="7.62" width="0.254" layer="20"/>
+<wire x1="54.392103125" y1="7.62" x2="52.59605" y2="8.36395" width="0.254" layer="20" curve="-45.00005"/>
+<wire x1="52.59605" y1="8.36395" x2="44.45" y2="16.51" width="0.254" layer="20"/>
+<wire x1="44.45" y1="16.51" x2="44.45" y2="27.94" width="0.254" layer="20"/>
+<wire x1="44.45" y1="27.94" x2="51.32605" y2="34.81605" width="0.254" layer="20"/>
+<wire x1="51.32605" y1="34.81605" x2="53.122103125" y2="35.56" width="0.254" layer="20" curve="-45.00007"/>
+<wire x1="53.122103125" y1="35.56" x2="59.69" y2="35.56" width="0.254" layer="20"/>
+<wire x1="59.69" y1="35.56" x2="63.5" y2="38.1" width="0.254" layer="20" curve="90"/>
+<wire x1="63.5" y1="38.1" x2="63.5" y2="52.07" width="0.254" layer="20"/>
+<wire x1="63.5" y1="52.07" x2="59.69" y2="55.88" width="0.254" layer="20" curve="90"/>
+<wire x1="59.69" y1="55.88" x2="2.54" y2="55.88" width="0.254" layer="20"/>
+<wire x1="2.54" y1="55.88" x2="-1.27" y2="52.07" width="0.254" layer="20" curve="90"/>
+<hole x="21.59" y="34.29" drill="1.397"/>
+<hole x="24.13" y="34.29" drill="1.397"/>
+<hole x="26.67" y="34.29" drill="1.397"/>
+<hole x="29.21" y="34.29" drill="1.397"/>
+<hole x="31.75" y="34.29" drill="1.397"/>
+<hole x="34.29" y="34.29" drill="1.397"/>
+<hole x="36.83" y="34.29" drill="1.397"/>
+<hole x="39.37" y="34.29" drill="1.397"/>
+<hole x="24.13" y="29.21" drill="1.397"/>
+<hole x="26.67" y="29.21" drill="1.397"/>
+<hole x="29.21" y="29.21" drill="1.397"/>
+<hole x="31.75" y="29.21" drill="1.397"/>
+<hole x="34.29" y="29.21" drill="1.397"/>
+<hole x="36.83" y="29.21" drill="1.397"/>
+<hole x="21.59" y="11.43" drill="1.397"/>
+<hole x="24.13" y="11.43" drill="1.397"/>
+<hole x="26.67" y="11.43" drill="1.397"/>
+<hole x="29.21" y="11.43" drill="1.397"/>
+<hole x="31.75" y="11.43" drill="1.397"/>
+<hole x="34.29" y="11.43" drill="1.397"/>
+<hole x="36.83" y="11.43" drill="1.397"/>
+<hole x="39.37" y="11.43" drill="1.397"/>
+<hole x="16.51" y="17.78" drill="1.397"/>
 </plain>
 <libraries>
 <library name="SparkFun">
@@ -254,32 +279,6 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <text x="-20.32" y="5.08" size="1.778" layer="51" font="vector">Released under the Creative Commons Attribution Share-Alike 4.0 License</text>
 <text x="0" y="2.54" size="1.778" layer="51" font="vector"> https://creativecommons.org/licenses/by-sa/4.0/</text>
 <text x="11.43" y="0" size="1.778" layer="51" font="vector">Designed by:</text>
-</package>
-</packages>
-</library>
-<library name="Pogo-Footprints">
-<packages>
-<package name="1X01_POGO_HEAD">
-<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="1.27" y1="0.635" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
-<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
-<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
-<pad name="1" x="0" y="0" drill="1.6002" diameter="1.778"/>
-</package>
-</packages>
-</library>
-<library name="KevinKuwata_eagle">
-<packages>
-<package name="POGO_PIN_TIGHT">
-<pad name="P1" x="0" y="0" drill="1.45" diameter="2.1844"/>
-<text x="-1.27" y="1.27" size="1.27" layer="25">&gt;NAME</text>
-<text x="-1.27" y="-2.54" size="1.27" layer="27">&gt;VALUE</text>
 </package>
 </packages>
 </library>
@@ -478,29 +477,6 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 <element name="JP2" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="59.69" y="2.54"/>
 <element name="JP5" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="2.54" y="52.07"/>
 <element name="JP6" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="2.54" y="2.54"/>
-<element name="U$4" library="Pogo-Footprints" package="1X01_POGO_HEAD" value="POGO_HEAD_11" x="16.51" y="17.78"/>
-<element name="J1" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="21.59" y="34.29"/>
-<element name="J2" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="24.13" y="34.29"/>
-<element name="J3" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="26.67" y="34.29"/>
-<element name="J4" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="29.21" y="34.29"/>
-<element name="J5" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="31.75" y="34.29"/>
-<element name="J6" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="34.29" y="34.29"/>
-<element name="J7" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="36.83" y="34.29"/>
-<element name="J8" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="39.37" y="34.29"/>
-<element name="J9" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="24.13" y="29.21"/>
-<element name="J10" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="31.75" y="29.21"/>
-<element name="J11" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="26.67" y="29.21"/>
-<element name="J12" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="34.29" y="29.21"/>
-<element name="J13" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="29.21" y="29.21"/>
-<element name="J14" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="21.59" y="11.43"/>
-<element name="J15" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="36.83" y="29.21"/>
-<element name="J16" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="24.13" y="11.43"/>
-<element name="J17" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="26.67" y="11.43"/>
-<element name="J18" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="39.37" y="11.43"/>
-<element name="J19" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="29.21" y="11.43"/>
-<element name="J21" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="31.75" y="11.43"/>
-<element name="J23" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="34.29" y="11.43"/>
-<element name="J24" library="KevinKuwata_eagle" package="POGO_PIN_TIGHT" value="POGO_PINTIGHT" x="36.83" y="11.43"/>
 </elements>
 <signals>
 </signals>

--- a/Hardware/TestJig/Jig-Middle-Layer.sch
+++ b/Hardware/TestJig/Jig-Middle-Layer.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.7.0">
+<eagle version="7.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>
@@ -314,83 +314,6 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </deviceset>
 </devicesets>
 </library>
-<library name="Pogo-Footprints">
-<packages>
-<package name="1X01_POGO_HEAD">
-<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
-<wire x1="-1.27" y1="-0.635" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.2032" layer="21"/>
-<wire x1="1.27" y1="0.635" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
-<text x="-1.27" y="1.397" size="0.6096" layer="25" font="vector" ratio="20">&gt;NAME</text>
-<text x="-1.27" y="-2.032" size="0.6096" layer="27" font="vector" ratio="20">&gt;VALUE</text>
-<pad name="1" x="0" y="0" drill="1.6002" diameter="1.778"/>
-</package>
-</packages>
-<symbols>
-<symbol name="POGO_HEAD_1">
-<wire x1="3.81" y1="-2.54" x2="-2.54" y2="-2.54" width="0.4064" layer="94"/>
-<wire x1="1.27" y1="0" x2="2.54" y2="0" width="0.6096" layer="94"/>
-<wire x1="-2.54" y1="2.54" x2="-2.54" y2="-2.54" width="0.4064" layer="94"/>
-<wire x1="3.81" y1="-2.54" x2="3.81" y2="2.54" width="0.4064" layer="94"/>
-<wire x1="-2.54" y1="2.54" x2="3.81" y2="2.54" width="0.4064" layer="94"/>
-<text x="-2.54" y="-4.826" size="1.778" layer="96" font="vector">&gt;VALUE</text>
-<text x="-2.54" y="3.048" size="1.778" layer="95" font="vector">&gt;NAME</text>
-<text x="-1.27" y="-1.524" size="1.27" layer="94">Pogo
-Head</text>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="POGO_HEAD_1">
-<gates>
-<gate name="G$1" symbol="POGO_HEAD_1" x="0" y="0"/>
-</gates>
-<devices>
-<device name="1" package="1X01_POGO_HEAD">
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-</devicesets>
-</library>
-<library name="KevinKuwata_eagle">
-<packages>
-<package name="POGO_PIN_TIGHT">
-<pad name="P1" x="0" y="0" drill="1.45" diameter="2.1844"/>
-<text x="-1.27" y="1.27" size="1.27" layer="25">&gt;NAME</text>
-<text x="-1.27" y="-2.54" size="1.27" layer="27">&gt;VALUE</text>
-</package>
-</packages>
-<symbols>
-<symbol name="POGO_PIN">
-<pin name="P1" x="-2.54" y="0" length="short"/>
-<text x="-2.54" y="2.54" size="1.27" layer="95">&gt;NAME</text>
-<text x="-2.54" y="-2.54" size="1.27" layer="96">&gt;VALUE</text>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="POGO_PIN" prefix="J">
-<gates>
-<gate name="J1" symbol="POGO_PIN" x="0" y="0"/>
-</gates>
-<devices>
-<device name="TIGHT" package="POGO_PIN_TIGHT">
-<connects>
-<connect gate="J1" pin="P1" pad="P1"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-</devicesets>
-</library>
 </libraries>
 <attributes>
 </attributes>
@@ -404,29 +327,6 @@ Head</text>
 <part name="JP3" library="SparkFun" deviceset="STAND-OFF" device=""/>
 <part name="JP4" library="SparkFun" deviceset="STAND-OFF" device=""/>
 <part name="FRAME1" library="SparkFun-Aesthetics" deviceset="FRAME-LETTER" device=""/>
-<part name="U$4" library="Pogo-Footprints" deviceset="POGO_HEAD_1" device="1"/>
-<part name="J1" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J2" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J3" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J4" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J5" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J6" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J7" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J8" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J9" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J10" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J11" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J12" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J13" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J14" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J15" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J16" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J17" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J18" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J19" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J21" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J23" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
-<part name="J24" library="KevinKuwata_eagle" deviceset="POGO_PIN" device="TIGHT"/>
 </parts>
 <sheets>
 <sheet>
@@ -476,29 +376,6 @@ SPI</text>
 <instance part="JP4" gate="G$1" x="246.38" y="27.94"/>
 <instance part="FRAME1" gate="G$1" x="0" y="0"/>
 <instance part="FRAME1" gate="V" x="147.32" y="0"/>
-<instance part="U$4" gate="G$1" x="15.24" y="162.56"/>
-<instance part="J1" gate="J1" x="22.86" y="134.62"/>
-<instance part="J2" gate="J1" x="22.86" y="124.46"/>
-<instance part="J3" gate="J1" x="22.86" y="114.3"/>
-<instance part="J4" gate="J1" x="22.86" y="104.14"/>
-<instance part="J5" gate="J1" x="50.8" y="134.62"/>
-<instance part="J6" gate="J1" x="50.8" y="124.46"/>
-<instance part="J7" gate="J1" x="50.8" y="114.3"/>
-<instance part="J8" gate="J1" x="50.8" y="104.14"/>
-<instance part="J9" gate="J1" x="76.2" y="134.62"/>
-<instance part="J10" gate="J1" x="76.2" y="124.46"/>
-<instance part="J11" gate="J1" x="76.2" y="114.3"/>
-<instance part="J12" gate="J1" x="76.2" y="104.14"/>
-<instance part="J13" gate="J1" x="104.14" y="134.62"/>
-<instance part="J14" gate="J1" x="104.14" y="124.46"/>
-<instance part="J15" gate="J1" x="104.14" y="114.3"/>
-<instance part="J16" gate="J1" x="104.14" y="104.14"/>
-<instance part="J17" gate="J1" x="132.08" y="134.62"/>
-<instance part="J18" gate="J1" x="132.08" y="124.46"/>
-<instance part="J19" gate="J1" x="132.08" y="114.3"/>
-<instance part="J21" gate="J1" x="160.02" y="134.62"/>
-<instance part="J23" gate="J1" x="160.02" y="114.3"/>
-<instance part="J24" gate="J1" x="160.02" y="104.14"/>
 </instances>
 <busses>
 </busses>

--- a/Hardware/TestJig/Jig-Top-Layer.brd
+++ b/Hardware/TestJig/Jig-Top-Layer.brd
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.7.0">
+<eagle version="7.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.005" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.016" altunitdist="inch" altunit="inch"/>
 <layers>
-<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="1" name="Top" color="4" fill="1" visible="no" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
 <layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
 <layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
@@ -23,15 +23,15 @@
 <layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
 <layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
 <layer number="15" name="Route15" color="4" fill="6" visible="no" active="no"/>
-<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
-<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
-<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
-<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="no" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="no" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="yes"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="21" name="tPlace" color="16" fill="1" visible="yes" active="yes"/>
-<layer number="22" name="bPlace" color="14" fill="1" visible="yes" active="yes"/>
-<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="16" fill="1" visible="no" active="yes"/>
+<layer number="22" name="bPlace" color="14" fill="1" visible="no" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
 <layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
@@ -52,13 +52,13 @@
 <layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
-<layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
 <layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="13" fill="1" visible="no" active="yes"/>
 <layer number="50" name="dxf" color="7" fill="1" visible="no" active="yes"/>
-<layer number="51" name="tDocu" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="51" name="tDocu" color="6" fill="1" visible="no" active="yes"/>
 <layer number="52" name="bDocu" color="7" fill="1" visible="no" active="yes"/>
 <layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
@@ -156,11 +156,11 @@
 </layers>
 <board>
 <plain>
-<wire x1="14.605" y1="9.525" x2="14.605" y2="36.195" width="0.2032" layer="20"/>
-<wire x1="14.605" y1="36.195" x2="16.51" y2="36.195" width="0.2032" layer="20"/>
-<wire x1="44.45" y1="36.195" x2="46.355" y2="36.195" width="0.2032" layer="20"/>
-<wire x1="46.355" y1="36.195" x2="46.355" y2="9.525" width="0.2032" layer="20"/>
-<wire x1="46.355" y1="9.525" x2="44.45" y2="9.525" width="0.2032" layer="20"/>
+<wire x1="14.605" y1="9.525" x2="14.605" y2="36.195" width="0.2032" layer="49"/>
+<wire x1="14.605" y1="36.195" x2="16.51" y2="36.195" width="0.2032" layer="49"/>
+<wire x1="44.45" y1="36.195" x2="46.355" y2="36.195" width="0.2032" layer="49"/>
+<wire x1="46.355" y1="36.195" x2="46.355" y2="9.525" width="0.2032" layer="49"/>
+<wire x1="46.355" y1="9.525" x2="44.45" y2="9.525" width="0.2032" layer="49"/>
 <text x="29.21" y="12.7" size="1.016" layer="21" font="vector" ratio="15" rot="R90" align="center-left">3V3</text>
 <text x="31.75" y="12.7" size="1.016" layer="21" font="vector" ratio="15" rot="R90" align="center-left">SDA</text>
 <text x="34.29" y="12.7" size="1.016" layer="21" font="vector" ratio="15" rot="R90" align="center-left">SCL</text>
@@ -195,21 +195,62 @@
 <text x="21.59" y="12.7" size="1.016" layer="22" font="vector" ratio="15" rot="MR90" align="center-left">PS0</text>
 <text x="24.13" y="12.7" size="1.016" layer="21" font="vector" ratio="15" rot="R90" align="center-left">PS1</text>
 <text x="21.59" y="12.7" size="1.016" layer="21" font="vector" ratio="15" rot="R90" align="center-left">PS0</text>
-<wire x1="16.51" y1="9.525" x2="14.605" y2="9.525" width="0.2032" layer="20"/>
+<wire x1="16.51" y1="9.525" x2="14.605" y2="9.525" width="0.2032" layer="49"/>
 <wire x1="38.1" y1="30.48" x2="22.86" y2="30.48" width="0.1524" layer="22"/>
 <wire x1="22.86" y1="30.48" x2="22.86" y2="27.94" width="0.1524" layer="22"/>
 <wire x1="22.86" y1="27.94" x2="38.1" y2="27.94" width="0.1524" layer="22"/>
 <wire x1="38.1" y1="27.94" x2="38.1" y2="30.48" width="0.1524" layer="22"/>
-<wire x1="0" y1="0" x2="62.23" y2="0" width="0.254" layer="20"/>
-<wire x1="62.23" y1="0" x2="62.23" y2="54.61" width="0.254" layer="20"/>
-<wire x1="62.23" y1="54.61" x2="0" y2="54.61" width="0.254" layer="20"/>
-<wire x1="0" y1="54.61" x2="0" y2="0" width="0.254" layer="20"/>
-<wire x1="16.51" y1="36.195" x2="16.51" y2="40.64" width="0.2032" layer="20"/>
-<wire x1="16.51" y1="40.64" x2="44.45" y2="40.64" width="0.2032" layer="20"/>
-<wire x1="44.45" y1="40.64" x2="44.45" y2="36.195" width="0.2032" layer="20"/>
-<wire x1="16.51" y1="9.525" x2="16.51" y2="5.08" width="0.2032" layer="20"/>
-<wire x1="16.51" y1="5.08" x2="44.45" y2="5.08" width="0.2032" layer="20"/>
-<wire x1="44.45" y1="5.08" x2="44.45" y2="9.525" width="0.2032" layer="20"/>
+<wire x1="-1.27" y1="52.07" x2="-1.27" y2="2.54" width="0.254" layer="20"/>
+<wire x1="-1.27" y1="2.54" x2="2.54" y2="-1.27" width="0.254" layer="20" curve="90"/>
+<wire x1="2.54" y1="-1.27" x2="59.69" y2="-1.27" width="0.254" layer="20"/>
+<wire x1="59.69" y1="-1.27" x2="63.5" y2="2.54" width="0.254" layer="20" curve="90"/>
+<wire x1="63.5" y1="52.07" x2="59.69" y2="55.88" width="0.254" layer="20" curve="90"/>
+<wire x1="59.69" y1="55.88" x2="2.54" y2="55.88" width="0.254" layer="20"/>
+<wire x1="2.54" y1="55.88" x2="-1.27" y2="52.07" width="0.254" layer="20" curve="90"/>
+<wire x1="16.51" y1="36.195" x2="16.51" y2="40.64" width="0.2032" layer="49"/>
+<wire x1="16.51" y1="40.64" x2="44.45" y2="40.64" width="0.2032" layer="49"/>
+<wire x1="44.45" y1="40.64" x2="44.45" y2="36.195" width="0.2032" layer="49"/>
+<wire x1="16.51" y1="9.525" x2="16.51" y2="5.08" width="0.2032" layer="49"/>
+<wire x1="16.51" y1="5.08" x2="44.45" y2="5.08" width="0.2032" layer="49"/>
+<wire x1="44.45" y1="5.08" x2="44.45" y2="9.525" width="0.2032" layer="49"/>
+<wire x1="15.24" y1="35.56" x2="45.72" y2="35.56" width="0.2032" layer="51"/>
+<wire x1="45.72" y1="35.56" x2="45.72" y2="10.16" width="0.2032" layer="51"/>
+<wire x1="45.72" y1="10.16" x2="15.24" y2="10.16" width="0.2032" layer="51"/>
+<wire x1="63.5" y1="2.54" x2="63.5" y2="5.08" width="0.254" layer="20"/>
+<wire x1="63.5" y1="5.08" x2="59.69" y2="7.62" width="0.254" layer="20" curve="90"/>
+<wire x1="59.69" y1="7.62" x2="54.392103125" y2="7.62" width="0.254" layer="20"/>
+<wire x1="54.392103125" y1="7.62" x2="52.59605" y2="8.36395" width="0.254" layer="20" curve="-45.00005"/>
+<wire x1="52.59605" y1="8.36395" x2="47.361975" y2="13.598025" width="0.254" layer="20"/>
+<wire x1="47.361975" y1="13.598025" x2="46.46395" y2="13.97" width="0.254" layer="20" curve="45"/>
+<wire x1="46.46395" y1="13.97" x2="46.1264" y2="13.63245" width="0.254" layer="20" curve="90"/>
+<wire x1="46.1264" y1="13.63245" x2="46.1264" y2="11.43" width="0.254" layer="20"/>
+<wire x1="59.69" y1="35.56" x2="53.122103125" y2="35.56" width="0.254" layer="20"/>
+<wire x1="53.122103125" y1="35.56" x2="51.32605" y2="34.81605" width="0.254" layer="20" curve="45.00005"/>
+<wire x1="51.32605" y1="34.81605" x2="47.361975" y2="30.851975" width="0.254" layer="20"/>
+<wire x1="47.361975" y1="30.851975" x2="46.46395" y2="30.48" width="0.254" layer="20" curve="-45"/>
+<wire x1="46.46395" y1="30.48" x2="46.1264" y2="30.81755" width="0.254" layer="20" curve="-90"/>
+<wire x1="46.1264" y1="30.81755" x2="46.1264" y2="34.29" width="0.254" layer="20"/>
+<wire x1="59.69" y1="35.56" x2="63.5" y2="38.1" width="0.254" layer="20" curve="90"/>
+<wire x1="63.5" y1="38.1" x2="63.5" y2="52.07" width="0.254" layer="20"/>
+<wire x1="14.8336" y1="34.29" x2="14.8336" y2="11.43" width="0.254" layer="20"/>
+<wire x1="16.51" y1="9.7536" x2="44.45" y2="9.7536" width="0.254" layer="20"/>
+<wire x1="44.45" y1="35.9664" x2="16.51" y2="35.9664" width="0.254" layer="20"/>
+<wire x1="16.51" y1="35.9664" x2="16.51" y2="36.83" width="0.254" layer="20"/>
+<wire x1="16.51" y1="36.83" x2="13.97" y2="36.83" width="0.254" layer="20"/>
+<wire x1="13.97" y1="36.83" x2="13.97" y2="34.29" width="0.254" layer="20"/>
+<wire x1="13.97" y1="34.29" x2="14.8336" y2="34.29" width="0.254" layer="20"/>
+<wire x1="14.8336" y1="11.43" x2="13.97" y2="11.43" width="0.254" layer="20"/>
+<wire x1="13.97" y1="11.43" x2="13.97" y2="8.89" width="0.254" layer="20"/>
+<wire x1="13.97" y1="8.89" x2="16.51" y2="8.89" width="0.254" layer="20"/>
+<wire x1="16.51" y1="8.89" x2="16.51" y2="9.7536" width="0.254" layer="20"/>
+<wire x1="46.1264" y1="11.43" x2="46.99" y2="11.43" width="0.254" layer="20"/>
+<wire x1="46.99" y1="11.43" x2="46.99" y2="8.89" width="0.254" layer="20"/>
+<wire x1="46.99" y1="8.89" x2="44.45" y2="8.89" width="0.254" layer="20"/>
+<wire x1="44.45" y1="8.89" x2="44.45" y2="9.7536" width="0.254" layer="20"/>
+<wire x1="44.45" y1="35.9664" x2="44.45" y2="36.83" width="0.254" layer="20"/>
+<wire x1="44.45" y1="36.83" x2="46.99" y2="36.83" width="0.254" layer="20"/>
+<wire x1="46.99" y1="36.83" x2="46.99" y2="34.29" width="0.254" layer="20"/>
+<wire x1="46.99" y1="34.29" x2="46.1264" y2="34.29" width="0.254" layer="20"/>
 </plain>
 <libraries>
 <library name="SparkFun">
@@ -441,8 +482,6 @@ These rules have been curated by SparkFuns DFM commitee. After doing much resear
 </pass>
 </autorouter>
 <elements>
-<element name="JP3" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="17.78" y="33.02"/>
-<element name="JP4" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="43.18" y="33.02"/>
 <element name="FRAME1" library="SparkFun-Aesthetics" package="CREATIVE_COMMONS" value="FRAME-LETTER" x="-20.32" y="-17.78"/>
 <element name="JP1" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="2.54" y="52.07"/>
 <element name="JP2" library="SparkFun" package="STAND-OFF" value="STAND-OFF" x="59.69" y="52.07"/>

--- a/Hardware/TestJig/Jig-Top-Layer.sch
+++ b/Hardware/TestJig/Jig-Top-Layer.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.7.0">
+<eagle version="7.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>
@@ -156,56 +156,6 @@
 </layers>
 <schematic xreflabel="%F%N/%S" xrefpart="/%S.%C%R">
 <libraries>
-<library name="SparkFun">
-<packages>
-<package name="STAND-OFF">
-<description>&lt;b&gt;Stand Off&lt;/b&gt;&lt;p&gt;
-This is the mechanical footprint for a #4 phillips button head screw. Use the keepout ring to avoid running the screw head into surrounding components. SKU : PRT-00447</description>
-<wire x1="0" y1="1.8542" x2="0" y2="-1.8542" width="0.2032" layer="41" curve="-180"/>
-<wire x1="0" y1="-1.8542" x2="0" y2="1.8542" width="0.2032" layer="41" curve="-180"/>
-<wire x1="0" y1="-1.8542" x2="0" y2="1.8542" width="0.2032" layer="42" curve="180"/>
-<wire x1="0" y1="-1.8542" x2="0" y2="1.8542" width="0.2032" layer="42" curve="-180"/>
-<circle x="0" y="0" radius="2.794" width="0.127" layer="39"/>
-<hole x="0" y="0" drill="3.302"/>
-</package>
-<package name="STAND-OFF-TIGHT">
-<description>&lt;b&gt;Stand Off&lt;/b&gt;&lt;p&gt;
-This is the mechanical footprint for a #4 phillips button head screw. Use the keepout ring to avoid running the screw head into surrounding components. SKU : PRT-00447</description>
-<wire x1="0" y1="1.8542" x2="0" y2="-1.8542" width="0.2032" layer="41" curve="-180"/>
-<wire x1="0" y1="-1.8542" x2="0" y2="1.8542" width="0.2032" layer="41" curve="-180"/>
-<wire x1="0" y1="-1.8542" x2="0" y2="1.8542" width="0.2032" layer="42" curve="180"/>
-<wire x1="0" y1="-1.8542" x2="0" y2="1.8542" width="0.2032" layer="42" curve="-180"/>
-<circle x="0" y="0" radius="2.794" width="0.127" layer="39"/>
-<hole x="0" y="0" drill="3.048"/>
-</package>
-</packages>
-<symbols>
-<symbol name="STAND-OFF">
-<circle x="0" y="0" radius="1.27" width="0.254" layer="94"/>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="STAND-OFF" prefix="JP">
-<description>&lt;b&gt;Stand Off&lt;/b&gt;&lt;p&gt;
-This is the mechanical footprint for a #4 phillips button head screw. Use the keepout ring to avoid running the screw head into surrounding components. SKU : PRT-00447</description>
-<gates>
-<gate name="G$1" symbol="STAND-OFF" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="STAND-OFF">
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="TIGHT" package="STAND-OFF-TIGHT">
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-</devicesets>
-</library>
 <library name="SparkFun-Aesthetics">
 <description>&lt;h3&gt;SparkFun Aesthetics&lt;/h3&gt;
 This library contiains non-functional items such as logos, build/ordering notes, frame blocks, etc. 
@@ -324,8 +274,6 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </class>
 </classes>
 <parts>
-<part name="JP3" library="SparkFun" deviceset="STAND-OFF" device=""/>
-<part name="JP4" library="SparkFun" deviceset="STAND-OFF" device=""/>
 <part name="FRAME1" library="SparkFun-Aesthetics" deviceset="FRAME-LETTER" device=""/>
 </parts>
 <sheets>
@@ -372,8 +320,6 @@ SPI</text>
 <wire x1="93.98" y1="91.44" x2="93.98" y2="0" width="0.2032" layer="97"/>
 </plain>
 <instances>
-<instance part="JP3" gate="G$1" x="246.38" y="30.48"/>
-<instance part="JP4" gate="G$1" x="246.38" y="27.94"/>
 <instance part="FRAME1" gate="G$1" x="0" y="0"/>
 <instance part="FRAME1" gate="V" x="147.32" y="0"/>
 </instances>


### PR DESCRIPTION
middle layer changes:
-changed holes for the pogopins to pup up through from pads to actual "holes" in eagle file. removed pads from sch and board.
-set hole size to 0.055 inch diameter for optimal lazer cutting in acrylic.

top layer changes:
-tightened up frame to huge product dimensions with 0.016 inch gap.
-added corner cutouts
-added "lift-out" cutout on the side, for easier product removal

Also note, bumped outer dimensions on both middle and top to allow for more strength around the corner standoff holes. Previous deisgn would probably crack if cut in acrylic with lazer.